### PR TITLE
command: add more tests for main aggregations

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -1,6 +1,7 @@
 package run_test
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -9,14 +10,46 @@ import (
 	"github.com/sourcegraph/run"
 )
 
-func TestRun(t *testing.T) {
+func TestRunAndAggregate(t *testing.T) {
 	c := qt.New(t)
+	ctx := context.Background()
 
-	c.Run(`echo "hello world"`, func(c *qt.C) {
-		// Easily stream all output back to standard out
-		lines, err := run.Cmd(context.Background(), "echo", "hello world").Run().Lines()
-		c.Assert(err, qt.IsNil)
-		c.Assert(len(lines), qt.Equals, 1)
-		c.Assert(lines[0], qt.Equals, "hello world")
+	command := `echo "hello world"`
+	c.Run(command, func(c *qt.C) {
+		c.Run("Lines", func(c *qt.C) {
+			lines, err := run.Cmd(ctx, command).Run().Lines()
+			c.Assert(err, qt.IsNil)
+			c.Assert(len(lines), qt.Equals, 1)
+			c.Assert(lines[0], qt.Equals, "hello world")
+		})
+
+		c.Run("Stream", func(c *qt.C) {
+			var b bytes.Buffer
+			err := run.Cmd(ctx, command).Run().Stream(&b)
+			c.Assert(err, qt.IsNil)
+			c.Assert(b.String(), qt.Equals, "hello world\n")
+		})
+
+		c.Run("StreamLines", func(c *qt.C) {
+			var lines [][]byte
+			err := run.Cmd(ctx, command).Run().StreamLines(func(line []byte) {
+				lines = append(lines, line)
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(len(lines), qt.Equals, 1)
+			c.Assert(string(lines[0]), qt.Equals, "hello world")
+		})
+
+		c.Run("Wait", func(c *qt.C) {
+			err := run.Cmd(ctx, command).Run().Wait()
+			c.Assert(err, qt.IsNil)
+		})
+
+		c.Run("Read", func(c *qt.C) {
+			b := make([]byte, 100)
+			n, err := run.Cmd(ctx, command).Run().Read(b)
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(b[0:n-1]), qt.Equals, "hello world\n")
+		})
 	})
 }


### PR DESCRIPTION
Adds a few more e2e-style test for ensuring the core aggregation paths work.