### PR TITLE
command: chain multiple inputs and add reset function

### DIFF
--- a/command.go
+++ b/command.go
@@ -55,13 +55,28 @@ func (c *Command) Dir(dir string) *Command {
 	return c
 }
 
-// Input pipes the given io.Reader to the command.
+// Input pipes the given io.Reader to the command. If an input is already set, the given
+// input is appended.
 func (c *Command) Input(input io.Reader) *Command {
 	if c.cmd == nil {
 		return c
 	}
 
-	c.cmd.Stdin = input
+	if c.cmd.Stdin != nil {
+		c.cmd.Stdin = io.MultiReader(c.cmd.Stdin, input)
+	} else {
+		c.cmd.Stdin = input
+	}
+	return c
+}
+
+// ResetInput sets the command's input to nil.
+func (c *Command) ResetInput() *Command {
+	if c.cmd == nil {
+		return c
+	}
+
+	c.cmd.Stdin = nil
 	return c
 }
 

--- a/command_test.go
+++ b/command_test.go
@@ -3,6 +3,7 @@ package run_test
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -51,5 +52,32 @@ func TestRunAndAggregate(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 			c.Assert(string(b[0:n-1]), qt.Equals, "hello world\n")
 		})
+	})
+}
+
+func TestInput(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	c.Run("set multiple inputs", func(c *qt.C) {
+		cmd := run.Cmd(ctx, "cat").
+			Input(strings.NewReader("hello")).
+			Input(strings.NewReader(" ")).
+			Input(strings.NewReader("world\n"))
+
+		lines, err := cmd.Run().Lines()
+		c.Assert(err, qt.IsNil)
+		c.Assert(lines[0], qt.Equals, "hello world")
+	})
+
+	c.Run("reset input", func(c *qt.C) {
+		cmd := run.Cmd(ctx, "cat").
+			Input(strings.NewReader("hello")).
+			ResetInput().
+			Input(strings.NewReader("world"))
+
+		lines, err := cmd.Run().Lines()
+		c.Assert(err, qt.IsNil)
+		c.Assert(lines[0], qt.Equals, "world")
 	})
 }


### PR DESCRIPTION
Was thinking this might be surprising behaviour, and I can definitely see a use case where you might incrementally build up some input to provide and expect `.Input` multiple times to work nicely.

To go with this new behaviour, adds `.ResetInput` to clear the input for real.