### PR TITLE
codeowners: add explicit codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+* @bobheadxi
+* @jhchabran
+* @danieldides
+* @michaellzc


### PR DESCRIPTION
This is a small project, so for now just add a list of codeowners for all changes based on active users of this repo