### PR TITLE
output: export NewErrorOutput for building Outputs that just error

### DIFF
--- a/command.go
+++ b/command.go
@@ -38,10 +38,10 @@ func Cmd(ctx context.Context, parts ...string) *Command {
 // Run starts command execution and returns Output, which defaults to combined output.
 func (c *Command) Run() Output {
 	if c.buildError != nil {
-		return newErrorOutput(c.buildError)
+		return NewErrorOutput(c.buildError)
 	}
 	if c.cmd == nil {
-		return newErrorOutput(errors.New("Command not instantiated"))
+		return NewErrorOutput(errors.New("Command not instantiated"))
 	}
 
 	return attachOutputAndRun(c.ctx, c.cmd)

--- a/output.go
+++ b/output.go
@@ -65,14 +65,14 @@ func attachOutputAndRun(ctx context.Context, cmd *exec.Cmd) Output {
 
 	combinedReader, combinedWriter, err := os.Pipe()
 	if err != nil {
-		return newErrorOutput(err)
+		return NewErrorOutput(err)
 	}
 	closers = append(closers, combinedReader, combinedWriter)
 
 	// Pipe stdout
 	stdoutReader, stdoutWriter, err := os.Pipe()
 	if err != nil {
-		return newErrorOutput(err)
+		return NewErrorOutput(err)
 	}
 	closers = append(closers, stdoutReader, stdoutWriter)
 	cmd.Stdout = io.MultiWriter(stdoutWriter, combinedWriter)
@@ -82,7 +82,7 @@ func attachOutputAndRun(ctx context.Context, cmd *exec.Cmd) Output {
 	// creation.
 	stderrReader, stderrWriter, err := os.Pipe()
 	if err != nil {
-		return newErrorOutput(err)
+		return NewErrorOutput(err)
 	}
 	closers = append(closers, stderrReader, stderrWriter)
 	var stderrCopy bytes.Buffer
@@ -90,7 +90,7 @@ func attachOutputAndRun(ctx context.Context, cmd *exec.Cmd) Output {
 
 	// Start command execution
 	if err := cmd.Start(); err != nil {
-		return newErrorOutput(err)
+		return NewErrorOutput(err)
 	}
 
 	return &commandOutput{

--- a/output_error.go
+++ b/output_error.go
@@ -4,8 +4,10 @@ import "io"
 
 type errorOutput struct{ err error }
 
-// newErrorOutput creates an Output that just returns error.
-func newErrorOutput(err error) Output { return &errorOutput{err: err} }
+// NewErrorOutput creates an Output that just returns error. Useful for allowing function
+// that help run Commands and want to just return an Output even if errors can happen
+// before command execution.
+func NewErrorOutput(err error) Output { return &errorOutput{err: err} }
 
 func (o *errorOutput) StdErr() Output                  { return o }
 func (o *errorOutput) StdOut() Output                  { return o }


### PR DESCRIPTION
I want to add a `root.Run(cmd *run.Command)` in `sg`, which will get `RepositoryRoot` and set the directory on `Command`. However, `RepositoryRoot` can error, so it would be nice to have `errorOutput` available so that we don't need to do `func Run(cmd *run.Command) (Output, error)` and can instead have a cleaner `func Run(cmd *run.Command) Output`

See: https://github.com/sourcegraph/sourcegraph/pull/35399