### PR TITLE
output: use unbounded buffers, add simple load test

### DIFF
--- a/load_test.go
+++ b/load_test.go
@@ -1,0 +1,29 @@
+package run
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestLargeOutput(t *testing.T) {
+	c := qt.New(t)
+
+	// Set buffer size to very small so we can trigger limits easily
+	defaultMaxBufferSize := maxBufferSize
+	maxBufferSize = 1024
+	c.Cleanup(func() { maxBufferSize = defaultMaxBufferSize })
+
+	// Use LICENSE as the large output for testing:
+	//
+	// 	$ wc -c "LICENSE" | awk '{print $1}'
+	// 	11347
+	//
+	// If LICENSE changes, this test may need to be updated.
+	var out bytes.Buffer
+	err := Cmd(context.Background(), "cat ./LICENSE").Run().Stream(&out)
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.Len(), qt.Equals, 11347, qt.Commentf("Only got %d bytes", out.Len()))
+}

--- a/output.go
+++ b/output.go
@@ -62,23 +62,34 @@ type commandOutput struct {
 
 var _ Output = &commandOutput{}
 
-const maxBufferSize = 128 * 1024
+var maxBufferSize int64 = 128 * 1024
 
 func attachOutputAndRun(ctx context.Context, cmd *exec.Cmd) Output {
 	closers := make([]io.Closer, 0, 3*2)
 
-	combinedReader, combinedWriter := nio.Pipe(buffer.New(maxBufferSize))
+	// Use unbounded buffers that create files of size fileBuffersSize to store overflow.
+	//
+	// TODO: We might be able to use ring buffers here to recycle memory, but it doesn't
+	// seem to work with large inputs out of the box - data can end up truncated before
+	// reads complete.
+	fileBuffersSize := maxBufferSize / int64(4)
+	combinedBuffer := buffer.NewUnboundedBuffer(maxBufferSize, fileBuffersSize)
+	stdoutBuffer := buffer.NewUnboundedBuffer(maxBufferSize, fileBuffersSize)
+	stderrBuffer := buffer.NewUnboundedBuffer(maxBufferSize, fileBuffersSize)
+
+	// Pipe for combined output
+	combinedReader, combinedWriter := nio.Pipe(combinedBuffer)
 	closers = append(closers, combinedReader, combinedWriter)
 
 	// Pipe stdout
-	stdoutReader, stdoutWriter := nio.Pipe(buffer.New(maxBufferSize))
+	stdoutReader, stdoutWriter := nio.Pipe(stdoutBuffer)
 	closers = append(closers, stdoutReader, stdoutWriter)
 	cmd.Stdout = io.MultiWriter(stdoutWriter, combinedWriter)
 
 	// Pipe stderr. We use a custom pipe because cmd.StderrPipe seems to have side effects
-	// that breaks io.MultiError, which we need to retain a copy of stderr for error
+	// that breaks io.MultiWriter, which we need to retain a copy of stderr for error
 	// creation.
-	stderrReader, stderrWriter := nio.Pipe(buffer.New(maxBufferSize))
+	stderrReader, stderrWriter := nio.Pipe(stderrBuffer)
 	closers = append(closers, stderrReader, stderrWriter)
 	var stderrCopy bytes.Buffer
 	cmd.Stderr = io.MultiWriter(&stderrCopy, stderrWriter, combinedWriter)
@@ -101,9 +112,12 @@ func attachOutputAndRun(ctx context.Context, cmd *exec.Cmd) Output {
 			// Define cleanup for command
 			waitFunc: func() (error, *bytes.Buffer) {
 				cmdErr := cmd.Wait()
+
+				// Stop all read/write operations
 				for _, closer := range closers {
 					closer.Close()
 				}
+
 				return cmdErr, &stderrCopy
 			},
 		},


### PR DESCRIPTION
The new unbounded buffer writes overflow to disk on incremental files of size `32 * 1024`.

Closes https://github.com/sourcegraph/run/issues/20