### PR TITLE
command: add Bash convenience constructor

### DIFF
--- a/cmd/pollexample/main.go
+++ b/cmd/pollexample/main.go
@@ -12,7 +12,7 @@ func main() {
 	ctx := context.Background()
 
 	// Demonstrate that output streams live!
-	cmd := run.Cmd(ctx, "bash -c", `'for i in {1..10}; do echo -n "This is a test in loop $i "; date ; sleep 1; done'`)
+	cmd := run.Bash(ctx, `for i in {1..10}; do echo -n "This is a test in loop $i "; date ; sleep 1; done`)
 	if err := cmd.Run().Stream(os.Stdout); err != nil {
 		log.Fatal(err)
 	}

--- a/command.go
+++ b/command.go
@@ -35,6 +35,11 @@ func Cmd(ctx context.Context, parts ...string) *Command {
 	}
 }
 
+// Bash joins all the parts and builds a command from it to be run by 'bash -c'.
+func Bash(ctx context.Context, parts ...string) *Command {
+	return Cmd(ctx, "bash -c", shell.Quote(strings.Join(parts, " ")))
+}
+
 // Run starts command execution and returns Output, which defaults to combined output.
 func (c *Command) Run() Output {
 	if c.buildError != nil {


### PR DESCRIPTION
Replaces the paradigm `Cmd(ctx, "bash -c", "foobar")`