### PR TITLE
output: rework LineFilter API as LineMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ func main() {
     log.Fatal(err.Error())
   }
 
-  // Or collect filter and modify standard out, then collect string lines from it
+  // Or collect, map, and modify output, then collect string lines from it
   lines, err := run.Cmd(ctx, "ls").Run().
     Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
       if !bytes.HasSuffix(line, []byte(".go")) {

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ import (
   "bytes"
   "context"
   "fmt"
+  "io"
   "log"
   "os"
 
@@ -32,11 +33,11 @@ func main() {
 
   // Or collect filter and modify standard out, then collect string lines from it
   lines, err := run.Cmd(ctx, "ls").Run().
-    Filter(func(s []byte) ([]byte, bool) {
-      if !bytes.HasSuffix(s, []byte(".go")) {
-        return nil, true
+    Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+      if !bytes.HasSuffix(line, []byte(".go")) {
+        return 0, nil
       }
-      return bytes.TrimSuffix(s, []byte(".go")), false
+      return dst.Write(bytes.TrimSuffix(line, []byte(".go")))
     }).
     Lines()
   if err != nil {
@@ -56,8 +57,8 @@ func main() {
   var exampleData bytes.Buffer
   exampleData.Write([]byte(exampleStart + "\n\n```go\n"))
   if err = run.Cmd(ctx, "cat", "cmd/example/main.go").Run().
-    Filter(func(line []byte) ([]byte, bool) {
-      return bytes.ReplaceAll(line, []byte("\t"), []byte("  ")), false
+    Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+      return dst.Write(bytes.ReplaceAll(line, []byte("\t"), []byte("  ")))
     }).
     Stream(&exampleData); err != nil {
     log.Fatal(err)

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -20,7 +20,7 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	// Or collect filter and modify standard out, then collect string lines from it
+	// Or collect, map, and modify output, then collect string lines from it
 	lines, err := run.Cmd(ctx, "ls").Run().
 		Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
 			if !bytes.HasSuffix(line, []byte(".go")) {

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -22,7 +22,7 @@ func main() {
 
 	// Or collect filter and modify standard out, then collect string lines from it
 	lines, err := run.Cmd(ctx, "ls").Run().
-		Filter(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+		Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
 			if !bytes.HasSuffix(line, []byte(".go")) {
 				return 0, nil
 			}
@@ -46,7 +46,7 @@ func main() {
 	var exampleData bytes.Buffer
 	exampleData.Write([]byte(exampleStart + "\n\n```go\n"))
 	if err = run.Cmd(ctx, "cat", "cmd/example/main.go").Run().
-		Filter(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+		Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
 			return dst.Write(bytes.ReplaceAll(line, []byte("\t"), []byte("  ")))
 		}).
 		Stream(&exampleData); err != nil {

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
 
@@ -21,11 +22,11 @@ func main() {
 
 	// Or collect filter and modify standard out, then collect string lines from it
 	lines, err := run.Cmd(ctx, "ls").Run().
-		Filter(func(s []byte) ([]byte, bool) {
-			if !bytes.HasSuffix(s, []byte(".go")) {
-				return nil, true
+		Filter(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+			if !bytes.HasSuffix(line, []byte(".go")) {
+				return 0, nil
 			}
-			return bytes.TrimSuffix(s, []byte(".go")), false
+			return dst.Write(bytes.TrimSuffix(line, []byte(".go")))
 		}).
 		Lines()
 	if err != nil {
@@ -45,8 +46,8 @@ func main() {
 	var exampleData bytes.Buffer
 	exampleData.Write([]byte(exampleStart + "\n\n```go\n"))
 	if err = run.Cmd(ctx, "cat", "cmd/example/main.go").Run().
-		Filter(func(line []byte) ([]byte, bool) {
-			return bytes.ReplaceAll(line, []byte("\t"), []byte("  ")), false
+		Filter(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+			return dst.Write(bytes.ReplaceAll(line, []byte("\t"), []byte("  ")))
 		}).
 		Stream(&exampleData); err != nil {
 		log.Fatal(err)

--- a/cmd/pipeexample/main.go
+++ b/cmd/pipeexample/main.go
@@ -14,7 +14,7 @@ func main() {
 
 	// Run command and get Output
 	lsOut := run.Cmd(ctx, "ls cmd").Run().
-		Filter(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+		Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
 			return dst.Write(append([]byte("./cmd/"), line...))
 		})
 

--- a/cmd/pipeexample/main.go
+++ b/cmd/pipeexample/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"log"
 	"os"
 
@@ -13,8 +14,8 @@ func main() {
 
 	// Run command and get Output
 	lsOut := run.Cmd(ctx, "ls cmd").Run().
-		Filter(func(line []byte) ([]byte, bool) {
-			return append([]byte("./cmd/"), line...), false
+		Filter(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+			return dst.Write(append([]byte("./cmd/"), line...))
 		})
 
 	// Pipe Output directly to another command!

--- a/cmd/pollexample/main.go
+++ b/cmd/pollexample/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"log"
 	"os"
 
@@ -13,7 +15,18 @@ func main() {
 
 	// Demonstrate that output streams live!
 	cmd := run.Bash(ctx, `for i in {1..10}; do echo -n "This is a test in loop $i "; date ; sleep 1; done`)
-	if err := cmd.Run().Stream(os.Stdout); err != nil {
+	if err := cmd.Run().
+		Filter(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+			if bytes.Contains(line, []byte("loop 3")) {
+				written, err := run.Cmd(ctx, "echo", "Loop 3 detected, running a subcommand!").
+					Run().
+					WriteTo(dst)
+				return int(written), err
+			}
+
+			return dst.Write(line)
+		}).
+		Stream(os.Stdout); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/pollexample/main.go
+++ b/cmd/pollexample/main.go
@@ -16,7 +16,7 @@ func main() {
 	// Demonstrate that output streams live!
 	cmd := run.Bash(ctx, `for i in {1..10}; do echo -n "This is a test in loop $i "; date ; sleep 1; done`)
 	if err := cmd.Run().
-		Filter(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+		Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
 			if bytes.Contains(line, []byte("loop 3")) {
 				defer cancel() // Interrupt parent context here
 

--- a/cmd/pollexample/main.go
+++ b/cmd/pollexample/main.go
@@ -18,7 +18,7 @@ func main() {
 	if err := cmd.Run().
 		Filter(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
 			if bytes.Contains(line, []byte("loop 3")) {
-				defer cancel()
+				defer cancel() // Interrupt parent context here
 
 				written, err := run.Cmd(ctx, "echo", "Loop 3 detected, running a subcommand!").
 					Run().

--- a/cmd/pollexample/main.go
+++ b/cmd/pollexample/main.go
@@ -11,13 +11,15 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 
 	// Demonstrate that output streams live!
 	cmd := run.Bash(ctx, `for i in {1..10}; do echo -n "This is a test in loop $i "; date ; sleep 1; done`)
 	if err := cmd.Run().
 		Filter(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
 			if bytes.Contains(line, []byte("loop 3")) {
+				defer cancel()
+
 				written, err := run.Cmd(ctx, "echo", "Loop 3 detected, running a subcommand!").
 					Run().
 					WriteTo(dst)

--- a/line_filter.go
+++ b/line_filter.go
@@ -6,7 +6,8 @@ import (
 )
 
 // LineFilter allows modifications of individual lines from Output and enables callbacks
-// that operate on lines from Output.
+// that operate on lines from Output. Bytes written to dst are collected and passed to
+// subsequent LineFilters before being written to output aggregation, e.g. Output.Stream().
 //
 // The return value mirrors the signature of (Writer).Write(), and should be used to
 // indicate what was written to dst.

--- a/map.go
+++ b/map.go
@@ -5,19 +5,22 @@ import (
 	"io"
 )
 
-// LineFilter allows modifications of individual lines from Output and enables callbacks
+// LineMap allows modifications of individual lines from Output and enables callbacks
 // that operate on lines from Output. Bytes written to dst are collected and passed to
-// subsequent LineFilters before being written to output aggregation, e.g. Output.Stream().
+// subsequent LineMaps before being written to output aggregation, e.g. Output.Stream().
 //
 // The return value mirrors the signature of (Writer).Write(), and should be used to
 // indicate what was written to dst.
-type LineFilter func(ctx context.Context, line []byte, dst io.Writer) (int, error)
+//
+// Errors interrupt line processing and are returned if and only if the command itself
+// did not exit with an error.
+type LineMap func(ctx context.Context, line []byte, dst io.Writer) (int, error)
 
-// JQFilter creates a LineFilter that executes a JQ query against each line. Errors at
-// runtime get written to output.
+// MapJQ creates a LineMap that executes a JQ query against each line and replaces the
+// output with the result.
 //
 // Refer to https://github.com/itchyny/gojq for the specifics of supported syntax.
-func JQFilter(query string) (LineFilter, error) {
+func MapJQ(query string) (LineMap, error) {
 	jqCode, err := buildJQ(query)
 	if err != nil {
 		return nil, err

--- a/map_test.go
+++ b/map_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/run"
 )
 
-func TestJQFilter(t *testing.T) {
+func TestJQMap(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
 
@@ -18,13 +18,13 @@ func TestJQFilter(t *testing.T) {
 {"msg":"hi robert!"}
 `
 
-	filter, err := run.JQFilter(".msg")
+	jqMap, err := run.MapJQ(".msg")
 	c.Assert(err, qt.IsNil)
 
 	lines, err := run.Cmd(ctx, "cat").
 		Input(strings.NewReader(jsonLines)).
 		Run().
-		Filter(filter).
+		Map(jqMap).
 		Lines()
 	c.Assert(err, qt.IsNil)
 	c.Assert(lines, qt.CmpEquals(), []string{

--- a/output.go
+++ b/output.go
@@ -31,13 +31,13 @@ type Output interface {
 	// TODO wishlist functionality
 	// Mode(mode OutputMode) Output
 
-	// Stream writes filtered output from the command to the destination writer until
+	// Stream writes mapped output from the command to the destination writer until
 	// command completion.
 	Stream(dst io.Writer) error
-	// StreamLines writes filtered output from the command and sends it line by line to the
+	// StreamLines writes mapped output from the command and sends it line by line to the
 	// destination callback until command completion.
 	StreamLines(dst func(line []byte)) error
-	// Lines waits for command completion and aggregates filtered output from the command.
+	// Lines waits for command completion and aggregates mapped output from the command.
 	Lines() ([]string, error)
 	// JQ waits for command completion executes a JQ query against the entire output.
 	//
@@ -46,7 +46,7 @@ type Output interface {
 	// Reader is implemented so that Output can be provided directly to another Command
 	// using Input().
 	io.Reader
-	// WriterTo is implemented for convenience when chaining commands in LineFilter.
+	// WriterTo is implemented for convenience when chaining commands in LineMap.
 	io.WriterTo
 
 	// Wait waits for command completion and returns.

--- a/output.go
+++ b/output.go
@@ -44,6 +44,8 @@ type Output interface {
 	// Reader is implemented so that Output can be provided directly to another Command
 	// using Input().
 	io.Reader
+	// WriterTo is implemented for convenience when chaining commands in LineFilter.
+	io.WriterTo
 
 	// Wait waits for command completion and returns.
 	Wait() error

--- a/output.go
+++ b/output.go
@@ -22,9 +22,11 @@ type Output interface {
 	// StdErr configures this Output to only provide StdErr. By default, Output works with
 	// combined output.
 	StdErr() Output
-	// Filter adds a filter to this Output. It is only applied at aggregation time using
-	// e.g. Stream, Lines, and so on.
-	Filter(filter LineFilter) Output
+	// Map adds a LineMap function to be applied to this Output. It is only applied at
+	// aggregation time using e.g. Stream, Lines, and so on. Multiple LineMaps are applied
+	// sequentially, with the result of previous LineMaps propagated to subsequent
+	// LineMaps.
+	Map(f LineMap) Output
 
 	// TODO wishlist functionality
 	// Mode(mode OutputMode) Output
@@ -136,7 +138,7 @@ func (o *commandOutput) StdErr() Output {
 	return o
 }
 
-func (o *commandOutput) Filter(filter LineFilter) Output {
-	o.aggregator.filterFuncs = append(o.aggregator.filterFuncs, filter)
+func (o *commandOutput) Map(f LineMap) Output {
+	o.aggregator.mapFuncs = append(o.aggregator.mapFuncs, f)
 	return o
 }

--- a/output_aggregator.go
+++ b/output_aggregator.go
@@ -80,7 +80,6 @@ func (a *aggregator) Lines() ([]string, error) {
 
 	// Wait for results
 	results := <-aggregatedC
-	println("results")
 
 	// done
 	if err != nil {
@@ -191,7 +190,10 @@ func (a *aggregator) mappedLinePipe(dst io.Writer, close func()) (int64, error) 
 	for scanner.Scan() {
 		line := scanner.Bytes()
 
-		var writeCalled bool
+		// Defaults to true because if no map funcs unset this, then we will write the
+		// entire line.
+		writeCalled := true
+
 		for _, f := range a.mapFuncs {
 			tb := &tracedBuffer{Buffer: &buf}
 			buffered, err := f(a.ctx, line, tb)

--- a/output_aggregator.go
+++ b/output_aggregator.go
@@ -211,8 +211,8 @@ func (a *aggregator) filteredLinePipe(dst io.Writer, close func()) (int64, error
 		}
 
 		// If anything was written, treat it as a line and add a line ending for
-		// convenience.
-		if buffered > 0 {
+		// convenience, unless it already has a line ending.
+		if buffered > 0 && !bytes.HasSuffix(line, []byte("\n")) {
 			written, err := dst.Write(append(line, '\n'))
 			totalWritten += int64(written)
 			if err != nil {

--- a/output_error.go
+++ b/output_error.go
@@ -18,5 +18,6 @@ func (o *errorOutput) StreamLines(dst func(line []byte)) error { return o.err }
 func (o *errorOutput) Lines() ([]string, error)                { return nil, o.err }
 func (o *errorOutput) JQ(query string) ([]byte, error)         { return nil, o.err }
 func (o *errorOutput) Read(p []byte) (int, error)              { return 0, o.err }
+func (o *errorOutput) WriteTo(io.Writer) (int64, error)        { return 0, o.err }
 
 func (o *errorOutput) Wait() error { return o.err }

--- a/output_error.go
+++ b/output_error.go
@@ -9,15 +9,15 @@ type errorOutput struct{ err error }
 // before command execution.
 func NewErrorOutput(err error) Output { return &errorOutput{err: err} }
 
-func (o *errorOutput) StdErr() Output                  { return o }
-func (o *errorOutput) StdOut() Output                  { return o }
-func (o *errorOutput) Filter(filter LineFilter) Output { return o }
+func (o *errorOutput) StdErr() Output     { return o }
+func (o *errorOutput) StdOut() Output     { return o }
+func (o *errorOutput) Map(LineMap) Output { return o }
 
-func (o *errorOutput) Stream(dst io.Writer) error              { return o.err }
-func (o *errorOutput) StreamLines(dst func(line []byte)) error { return o.err }
-func (o *errorOutput) Lines() ([]string, error)                { return nil, o.err }
-func (o *errorOutput) JQ(query string) ([]byte, error)         { return nil, o.err }
-func (o *errorOutput) Read(p []byte) (int, error)              { return 0, o.err }
-func (o *errorOutput) WriteTo(io.Writer) (int64, error)        { return 0, o.err }
+func (o *errorOutput) Stream(io.Writer) error           { return o.err }
+func (o *errorOutput) StreamLines(func([]byte)) error   { return o.err }
+func (o *errorOutput) Lines() ([]string, error)         { return nil, o.err }
+func (o *errorOutput) JQ(string) ([]byte, error)        { return nil, o.err }
+func (o *errorOutput) Read([]byte) (int, error)         { return 0, o.err }
+func (o *errorOutput) WriteTo(io.Writer) (int64, error) { return 0, o.err }
 
 func (o *errorOutput) Wait() error { return o.err }

--- a/writer.go
+++ b/writer.go
@@ -24,3 +24,15 @@ func (lw *lineWriter) Write(b []byte) (int, error) {
 
 	return n, nil
 }
+
+type tracedBuffer struct {
+	// writeCalled indicates that Write was called at all, even with empty input.
+	writeCalled bool
+
+	*bytes.Buffer
+}
+
+func (t *tracedBuffer) Write(b []byte) (int, error) {
+	t.writeCalled = true
+	return t.Buffer.Write(b)
+}

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,26 @@
+package run
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+)
+
+type lineWriter struct {
+	handler func([]byte)
+}
+
+func newLineWriter(handler func([]byte)) io.Writer {
+	return &lineWriter{handler: handler}
+}
+
+func (lw *lineWriter) Write(b []byte) (int, error) {
+	n := len(b)
+
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	for scanner.Scan() {
+		lw.handler(scanner.Bytes())
+	}
+
+	return n, nil
+}


### PR DESCRIPTION
Reworks the LineFilter API to include context and be more flexible to accommodate chaining patterns based on my thoughts in https://github.com/sourcegraph/run/issues/14 and [this thread](https://sourcegraph.slack.com/archives/C07KZF47K/p1652738100240049), for example:

```go
func main() {
	ctx, cancel := context.WithCancel(context.Background())

	// Demonstrate that output streams live!
	cmd := run.Bash(ctx, `for i in {1..10}; do echo -n "This is a test in loop $i "; date ; sleep 1; done`)
	if err := cmd.Run().
		Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
			if bytes.Contains(line, []byte("loop 3")) {
				defer cancel() // Interrupt parent context here

				written, err := run.Cmd(ctx, "echo", "Loop 3 detected, running a subcommand!").
					Run().
					WriteTo(dst)
				return int(written), err
			}

			return dst.Write(line)
		}).
		Stream(os.Stdout); err != nil {
		log.Fatal(err)
	}
}
```

Definitely starting to get a bit complicated code-wise though. Also, to enable chaining patterns on `LineFilter` we can't flush the output until all `LineFilter`s are executed, which can be quite awkward for streaming long-running commands. That said if those subcommand want streaming output, they should stream to `os.Stdout` instead, so maybe this all makes sense 😁 