### PR TITLE
output: add String() (string, error)

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -18,13 +18,6 @@ func TestRunAndAggregate(t *testing.T) {
 
 	command := `echo "hello world"`
 	c.Run(command, func(c *qt.C) {
-		c.Run("Lines", func(c *qt.C) {
-			lines, err := run.Cmd(ctx, command).Run().Lines()
-			c.Assert(err, qt.IsNil)
-			c.Assert(len(lines), qt.Equals, 1)
-			c.Assert(lines[0], qt.Equals, "hello world")
-		})
-
 		c.Run("Stream", func(c *qt.C) {
 			var b bytes.Buffer
 			err := run.Cmd(ctx, command).Run().Stream(&b)
@@ -46,6 +39,19 @@ func TestRunAndAggregate(t *testing.T) {
 			}
 			c.Assert(len(lines), qt.Equals, 1)
 			c.Assert(string(lines[0]), qt.Equals, "hello world")
+		})
+
+		c.Run("Lines", func(c *qt.C) {
+			lines, err := run.Cmd(ctx, command).Run().Lines()
+			c.Assert(err, qt.IsNil)
+			c.Assert(len(lines), qt.Equals, 1)
+			c.Assert(lines[0], qt.Equals, "hello world")
+		})
+
+		c.Run("String", func(c *qt.C) {
+			str, err := run.Cmd(ctx, command).Run().String()
+			c.Assert(err, qt.IsNil)
+			c.Assert(str, qt.Equals, "hello world")
 		})
 
 		c.Run("Read", func(c *qt.C) {

--- a/output.go
+++ b/output.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strings"
 
 	"github.com/djherbis/buffer"
 	"github.com/djherbis/nio/v3"
@@ -34,8 +35,12 @@ type Output interface {
 	// StreamLines writes mapped output from the command and sends it line by line to the
 	// destination callback until command completion.
 	StreamLines(dst func(line []byte)) error
-	// Lines waits for command completion and aggregates mapped output from the command.
+	// Lines waits for command completion and aggregates mapped output from the command as
+	// a slice of lines.
 	Lines() ([]string, error)
+	// Lines waits for command completion and aggregates mapped output from the command as
+	// a combined string.
+	String() (string, error)
 	// JQ waits for command completion executes a JQ query against the entire output.
 	//
 	// Refer to https://github.com/itchyny/gojq for the specifics of supported syntax.
@@ -225,6 +230,12 @@ func (o *commandOutput) JQ(query string) ([]byte, error) {
 		return nil, err
 	}
 	return b, nil
+}
+
+func (o *commandOutput) String() (string, error) {
+	var sb strings.Builder
+	err := o.Stream(&sb)
+	return strings.TrimSuffix(sb.String(), "\n"), err
 }
 
 func (o *commandOutput) Read(read []byte) (int, error) {

--- a/output_error.go
+++ b/output_error.go
@@ -16,6 +16,7 @@ func (o *errorOutput) Map(LineMap) Output { return o }
 func (o *errorOutput) Stream(io.Writer) error           { return o.err }
 func (o *errorOutput) StreamLines(func([]byte)) error   { return o.err }
 func (o *errorOutput) Lines() ([]string, error)         { return nil, o.err }
+func (o *errorOutput) String() (string, error)          { return "", o.err }
 func (o *errorOutput) JQ(string) ([]byte, error)        { return nil, o.err }
 func (o *errorOutput) Read([]byte) (int, error)         { return 0, o.err }
 func (o *errorOutput) WriteTo(io.Writer) (int64, error) { return 0, o.err }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/run/issues/28 by adding a (more efficient) alias for the common pattern of getting Lines() and joining it back into a single string.
