### PR TITLE
ci: run on all pushes

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,10 +1,6 @@
 name: Pipeline
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [ push ]
 
 jobs:
 


### PR DESCRIPTION
I'm not sure why the actions template recommended we use what we use, but it doesn't seem to work (https://github.com/sourcegraph/run/pull/30 does not have a pipeline run). This PR changes it to run on all push events

edit - ah, https://github.com/sourcegraph/run/pull/30 is a stacked PR