### PR TITLE
output: refactor error handling and fix io.Reader implementation

### DIFF
--- a/command.go
+++ b/command.go
@@ -97,15 +97,15 @@ func (c *Command) Environ(environ []string) *Command {
 	return c
 }
 
-// StdOut configures the command Output to only provide StdErr. By default, Output works
-// with combined output.
+// StdOut configures the command Output to only provide StdOut. By default, Output
+// includes combined output.
 func (c *Command) StdOut() *Command {
 	c.attach = attachOnlyStdOut
 	return c
 }
 
-// StdErr configures the command Output to only provide StdErr. By default, Output works
-// with combined output.
+// StdErr configures the command Output to only provide StdErr. By default, Output
+// includes combined output.
 func (c *Command) StdErr() *Command {
 	c.attach = attachOnlyStdErr
 	return c

--- a/output.go
+++ b/output.go
@@ -63,18 +63,18 @@ type commandOutput struct {
 	ctx context.Context
 
 	// reader is set to the reader side of the output pipe. It does not have mapFuncs
-	// applied, they are applied at aggregation time.
+	// applied, they are applied at aggregation time. When the command exits, the error
+	// should be raised from the reader after the reader's buffer is exhausted.
 	reader io.ReadCloser
-	// writer is set to the writer side of the output pipe. It should be closed with the
-	// error from waitFunc().
-	writer closerWithError
 
 	// mapFuncs define LineMaps to be applied at aggregation time.
 	mapFuncs []LineMap
 
-	// waitFunc is called before aggregation exit. It should only be called via doWaitOnce().
-	waitFunc func() error
-	waitOnce sync.Once
+	// waitAndCloseFunc should only be called via doWaitOnce(). It should wait for command
+	// exit and handle setting an error such that once reads from reader are complete, the
+	// reader should return the error from the command.
+	waitAndCloseFunc func() error
+	waitAndCloseOnce sync.Once
 }
 
 var _ Output = &commandOutput{}
@@ -91,36 +91,31 @@ const (
 
 func attachOutputAndRun(ctx context.Context, attach attachedOuput, cmd *exec.Cmd) Output {
 	// Use unbounded buffers that create files of size fileBuffersSize to store overflow.
-	//
-	// TODO: We might be able to use ring buffers here to recycle memory, but it doesn't
-	// seem to work with large inputs out of the box - data can end up truncated before
-	// reads complete.
 	fileBuffersSize := maxBufferSize / int64(4)
 	outputBuffer := buffer.NewUnboundedBuffer(maxBufferSize, fileBuffersSize)
+	// We need to retain a copy of stderr for error creation.
+	stderrCopy := buffer.NewUnboundedBuffer(maxBufferSize, fileBuffersSize)
+
+	// We use this buffered pipe from github.com/djherbis/nio that allows async read and
+	// write operations to the reader and writer portions of the pipe respectively.
 	outputReader, outputWriter := nio.Pipe(outputBuffer)
 
 	// Set up output hooks
 	switch attach {
 	case attachCombined:
 		cmd.Stdout = outputWriter
-		cmd.Stderr = outputWriter
+		cmd.Stderr = io.MultiWriter(stderrCopy, outputWriter)
 
 	case attachOnlyStdOut:
 		cmd.Stdout = outputWriter
+		cmd.Stderr = stderrCopy
 
 	case attachOnlyStdErr:
-		cmd.Stderr = outputWriter
+		cmd.Stdout = nil // discard
+		cmd.Stderr = io.MultiWriter(stderrCopy, outputWriter)
 
 	default:
 		return NewErrorOutput(fmt.Errorf("unexpected attach type %d", attach))
-	}
-
-	// We need to retain a copy of stderr for error creation.
-	stderrCopy := buffer.NewUnboundedBuffer(maxBufferSize, fileBuffersSize)
-	if cmd.Stderr != nil {
-		cmd.Stderr = io.MultiWriter(stderrCopy, cmd.Stderr)
-	} else {
-		cmd.Stderr = stderrCopy
 	}
 
 	// Start command execution
@@ -129,12 +124,15 @@ func attachOutputAndRun(ctx context.Context, attach attachedOuput, cmd *exec.Cmd
 	}
 
 	return &commandOutput{
-		ctx: ctx,
-
+		ctx:    ctx,
 		reader: outputReader,
-		writer: outputWriter,
-
-		waitFunc: func() error { return newError(cmd.Wait(), stderrCopy) },
+		waitAndCloseFunc: func() error {
+			err := newError(cmd.Wait(), stderrCopy)
+			// CloseWithError makes it so that when all output has been consumed from the
+			// reader, the given error is returned.
+			outputWriter.CloseWithError(err)
+			return err
+		},
 	}
 }
 
@@ -149,14 +147,14 @@ func (o *commandOutput) Stream(dst io.Writer) error {
 }
 
 func (o *commandOutput) StreamLines(dst func(line []byte)) error {
-	go o.doWaitOnce()
+	go o.waitAndClose()
 
 	_, err := o.mappedLinePipe(newLineWriter(dst), nil)
 	return err
 }
 
 func (o *commandOutput) Lines() ([]string, error) {
-	go o.doWaitOnce()
+	go o.waitAndClose()
 
 	// export lines
 	linesC := make(chan string, 3)
@@ -201,7 +199,7 @@ func (o *commandOutput) String() (string, error) {
 }
 
 func (o *commandOutput) Read(p []byte) (int, error) {
-	go o.doWaitOnce()
+	go o.waitAndClose()
 
 	return o.reader.Read(p)
 }
@@ -209,7 +207,7 @@ func (o *commandOutput) Read(p []byte) (int, error) {
 // WriteTo implements io.WriterTo, and returns int64 instead of int because of:
 // https://stackoverflow.com/questions/29658892/why-does-io-writertos-writeto-method-return-an-int64-rather-than-an-int
 func (o *commandOutput) WriteTo(dst io.Writer) (int64, error) {
-	go o.doWaitOnce()
+	go o.waitAndClose()
 
 	if len(o.mapFuncs) == 0 {
 		// Happy path, directly pipe output
@@ -220,21 +218,21 @@ func (o *commandOutput) WriteTo(dst io.Writer) (int64, error) {
 }
 
 func (o *commandOutput) Wait() error {
-	err := o.doWaitOnce()
-	// Wait does not consume output, prevent further reads from occuring.
+	err := o.waitAndClose()
+	// Wait does not consume output, so prevent further reads from occuring.
 	o.reader.Close()
 	return err
 }
 
-// goWaitOnce waits for command completion. Most callers do not need to use the returned
-// error - o.reader will be closed with the error, so operations that read from o.reader
-// can just use the error returned from reads instead.
-func (o *commandOutput) doWaitOnce() error {
-	// if err is not reset by waitOnce.Do, then output has already been consumed
+// goWaitOnce waits for command completion and closes the write half of the reader. Most
+// callers do not need to use the returned error - operations that read from o.reader
+// should return the error from that instead, which in most cases should be the same error.
+func (o *commandOutput) waitAndClose() error {
+	// If err is not reset by waitAndCloseOnce.Do, then output has already been consumed,
+	// and we raise this default error.
 	err := fmt.Errorf("output has already been consumed")
-	o.waitOnce.Do(func() {
-		err = o.waitFunc()
-		o.writer.CloseWithError(err)
+	o.waitAndCloseOnce.Do(func() {
+		err = o.waitAndCloseFunc()
 	})
 	return err
 }

--- a/writer.go
+++ b/writer.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-
-	"github.com/djherbis/nio/v3"
 )
 
 type lineWriter struct {
@@ -38,10 +36,3 @@ func (t *tracedBuffer) Write(b []byte) (int, error) {
 	t.writeCalled = true
 	return t.Buffer.Write(b)
 }
-
-// closerWithError is part of the buffer pipe writer interface for closing the pipe.
-type closerWithError interface {
-	CloseWithError(error) error
-}
-
-var _ closerWithError = &nio.PipeWriter{}

--- a/writer.go
+++ b/writer.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+
+	"github.com/djherbis/nio/v3"
 )
 
 type lineWriter struct {
@@ -36,3 +38,10 @@ func (t *tracedBuffer) Write(b []byte) (int, error) {
 	t.writeCalled = true
 	return t.Buffer.Write(b)
 }
+
+// closerWithError is part of the buffer pipe writer interface for closing the pipe.
+type closerWithError interface {
+	CloseWithError(error) error
+}
+
+var _ closerWithError = &nio.PipeWriter{}


### PR DESCRIPTION
Removes all the command-error-waiting stuff with a simple `writer.CloseWithError` - this means that read operations now return our command error _after the buffer is cleared from reads_. This greatly simplifies most of the output code - now, we can simply bubble up errors from read operations. It also means the io.Reader implementation is now correct (closes https://github.com/sourcegraph/run/issues/23)!

Real-life example that now works thanks to the updated io.Reader implementation: https://github.com/sourcegraph/sourcegraph/pull/35836