### PR TITLE
output: use io.Reader implementation more internally

### DIFF
--- a/map.go
+++ b/map.go
@@ -27,7 +27,7 @@ func MapJQ(query string) (LineMap, error) {
 	}
 
 	return func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
-		b, err := execJQ(ctx, jqCode, line)
+		b, err := execJQBytes(ctx, jqCode, line)
 		if err != nil {
 			return 0, err
 		}

--- a/output.go
+++ b/output.go
@@ -180,22 +180,19 @@ func (o *commandOutput) JQ(query string) ([]byte, error) {
 		return nil, err
 	}
 
-	var buffer bytes.Buffer
-	if err := o.Stream(&buffer); err != nil {
-		return nil, err
-	}
-
-	b, err := execJQ(o.ctx, jqCode, buffer.Bytes())
+	result, err := execJQ(o.ctx, jqCode, o)
 	if err != nil {
 		return nil, err
 	}
-	return b, nil
+	return result, nil
 }
 
 func (o *commandOutput) String() (string, error) {
-	var sb strings.Builder
-	err := o.Stream(&sb)
-	return strings.TrimSuffix(sb.String(), "\n"), err
+	b, err := io.ReadAll(o)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(string(b), "\n"), nil
 }
 
 func (o *commandOutput) Read(p []byte) (int, error) {


### PR DESCRIPTION
Replace internal `.Stream` usage with approaches that use `io` more instead, which was fixed in #32 . tl;dr more idiomatic Go code