### PR TITLE
output: fix io.Reader when used with LineMap

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -1,0 +1,17 @@
+package run
+
+import (
+	"github.com/djherbis/buffer"
+)
+
+// maxBufferSize denotes the maximum size of each buffer. Overflows are written to disk
+// at increments of this size.
+var maxBufferSize int64 = 128 * 1024
+
+// bufferPool will never return an error.
+//
+// Uses unbounded buffers that create files of size fileBuffersSize to store overflow.
+func makeBuffer() buffer.Buffer {
+	fileBuffersSize := maxBufferSize / int64(4)
+	return buffer.NewUnboundedBuffer(maxBufferSize, fileBuffersSize)
+}

--- a/buffer.go
+++ b/buffer.go
@@ -11,7 +11,7 @@ var maxBufferSize int64 = 128 * 1024
 // bufferPool will never return an error.
 //
 // Uses unbounded buffers that create files of size fileBuffersSize to store overflow.
-func makeBuffer() buffer.Buffer {
+func makeUnboundedBuffer() buffer.Buffer {
 	fileBuffersSize := maxBufferSize / int64(4)
 	return buffer.NewUnboundedBuffer(maxBufferSize, fileBuffersSize)
 }

--- a/command_test.go
+++ b/command_test.go
@@ -120,6 +120,19 @@ func TestRunAndAggregate(t *testing.T) {
 			},
 			expect: "goodbye world",
 		},
+		{
+			name: "multiple mapped output",
+			output: func() run.Output {
+				return run.Cmd(ctx, command).Run().
+					Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+						return dst.Write(bytes.ReplaceAll(line, []byte("hello"), []byte("goodbye")))
+					}).
+					Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+						return dst.Write(bytes.ReplaceAll(line, []byte("world"), []byte("jh")))
+					})
+			},
+			expect: "goodbye jh",
+		},
 	} {
 		c.Run(tc.name, func(c *qt.C) {
 			for _, test := range outputTests {

--- a/command_test.go
+++ b/command_test.go
@@ -3,6 +3,7 @@ package run_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -12,22 +13,19 @@ import (
 	"github.com/sourcegraph/run"
 )
 
-func TestRunAndAggregate(t *testing.T) {
-	c := qt.New(t)
-	ctx := context.Background()
-
-	command := `echo "hello world"`
-	c.Run(command, func(c *qt.C) {
+var outputTests = []func(c *qt.C, out run.Output, expect string){
+	func(c *qt.C, out run.Output, expect string) {
 		c.Run("Stream", func(c *qt.C) {
 			var b bytes.Buffer
-			err := run.Cmd(ctx, command).Run().Stream(&b)
+			err := out.Stream(&b)
 			c.Assert(err, qt.IsNil)
-			c.Assert(b.String(), qt.Equals, "hello world\n")
+			c.Assert(b.String(), qt.Equals, fmt.Sprintf("%s\n", expect))
 		})
-
+	},
+	func(c *qt.C, out run.Output, expect string) {
 		c.Run("StreamLines", func(c *qt.C) {
 			linesC := make(chan []byte, 10)
-			err := run.Cmd(ctx, command).Run().StreamLines(func(line []byte) {
+			err := out.StreamLines(func(line []byte) {
 				linesC <- line
 			})
 			c.Assert(err, qt.IsNil)
@@ -38,57 +36,102 @@ func TestRunAndAggregate(t *testing.T) {
 				lines = append(lines, l)
 			}
 			c.Assert(len(lines), qt.Equals, 1)
-			c.Assert(string(lines[0]), qt.Equals, "hello world")
+			c.Assert(string(lines[0]), qt.Equals, expect)
 		})
-
+	},
+	func(c *qt.C, out run.Output, expect string) {
 		c.Run("Lines", func(c *qt.C) {
-			lines, err := run.Cmd(ctx, command).Run().Lines()
+			lines, err := out.Lines()
 			c.Assert(err, qt.IsNil)
 			c.Assert(len(lines), qt.Equals, 1)
-			c.Assert(lines[0], qt.Equals, "hello world")
+			c.Assert(lines[0], qt.Equals, expect)
 		})
-
+	},
+	func(c *qt.C, out run.Output, expect string) {
 		c.Run("String", func(c *qt.C) {
-			str, err := run.Cmd(ctx, command).Run().String()
+			str, err := out.String()
 			c.Assert(err, qt.IsNil)
-			c.Assert(str, qt.Equals, "hello world")
+			c.Assert(str, qt.Equals, expect)
 		})
-
-		c.Run("Read", func(c *qt.C) {
-			c.Run("fixed bytes read", func(c *qt.C) {
-				b := make([]byte, 100)
-				n, err := run.Cmd(ctx, command).Run().Read(b)
-				c.Assert(err, qt.IsNil)
-				c.Assert(string(b[0:n]), qt.Equals, "hello world\n")
-			})
-
-			c.Run("read exactly length of output", func(c *qt.C) {
-				// Read exactly the amount of output
-				out := "hello world\n"
-				b := make([]byte, len(out))
-				output := run.Cmd(ctx, command).Run()
-				n, err := output.Read(b)
-				c.Assert(err, qt.IsNil)
-				c.Assert(string(b[0:n]), qt.Equals, out)
-
-				// A subsequent read should indicate nothing read, and an EOF
-				n, err = output.Read(make([]byte, 100))
-				c.Assert(n, qt.Equals, 0)
-				c.Assert(err, qt.Equals, io.EOF)
-			})
-
-			c.Run("io.ReadAll", func(c *qt.C) {
-				b, err := io.ReadAll(run.Cmd(ctx, command).Run())
-				c.Assert(err, qt.IsNil)
-				c.Assert(string(b), qt.Equals, "hello world\n")
-			})
+	},
+	func(c *qt.C, out run.Output, expect string) {
+		c.Run("Read: fixed bytes", func(c *qt.C) {
+			b := make([]byte, 100)
+			n, err := out.Read(b)
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(b[0:n]), qt.Equals, fmt.Sprintf("%s\n", expect))
 		})
+	},
+	func(c *qt.C, out run.Output, expect string) {
+		c.Run("Read: exactly length of output", func(c *qt.C) {
+			// Read exactly the amount of output
+			b := make([]byte, len(expect)+1)
+			n, err := out.Read(b)
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(b[0:n]), qt.Equals, fmt.Sprintf("%s\n", expect))
 
+			// A subsequent read should indicate nothing read, and an EOF
+			n, err = out.Read(make([]byte, 100))
+			c.Assert(n, qt.Equals, 0)
+			c.Assert(err, qt.Equals, io.EOF)
+		})
+	},
+	func(c *qt.C, out run.Output, expect string) {
+		c.Run("Read: io.ReadAll", func(c *qt.C) {
+			b, err := io.ReadAll(out)
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(b), qt.Equals, fmt.Sprintf("%s\n", expect))
+		})
+	},
+	func(c *qt.C, out run.Output, expect string) {
 		c.Run("Wait", func(c *qt.C) {
-			err := run.Cmd(ctx, command).Run().Wait()
+			err := out.Wait()
 			c.Assert(err, qt.IsNil)
 		})
-	})
+	},
+}
+
+func TestRunAndAggregate(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	command := `echo "hello world"`
+
+	type testCase struct {
+		name   string
+		output func() run.Output
+		expect string
+	}
+	for _, tc := range []testCase{
+		{
+			name: "plain output",
+			output: func() run.Output {
+				return run.Cmd(ctx, command).Run()
+			},
+			expect: "hello world",
+		},
+		{
+			name: "mapped output",
+			output: func() run.Output {
+				return run.Cmd(ctx, command).Run().
+					Map(func(ctx context.Context, line []byte, dst io.Writer) (int, error) {
+						return dst.Write(bytes.ReplaceAll(line, []byte("hello"), []byte("goodbye")))
+					})
+			},
+			expect: "goodbye world",
+		},
+	} {
+		c.Run(tc.name, func(c *qt.C) {
+			for _, test := range outputTests {
+				test(c, tc.output(), tc.expect)
+			}
+		})
+	}
+}
+
+func TestJQ(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
 
 	c.Run("cat and JQ", func(c *qt.C) {
 		const testJSON = `{
@@ -102,6 +145,12 @@ func TestRunAndAggregate(t *testing.T) {
 		c.Assert(err, qt.IsNil)
 		c.Assert(string(res), qt.Equals, `"world"`)
 	})
+
+}
+
+func TestEdgeCases(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
 
 	c.Run("empty lines from map are preserved", func(c *qt.C) {
 		const testData = `hello

--- a/output.go
+++ b/output.go
@@ -90,7 +90,7 @@ const (
 func attachOutputAndRun(ctx context.Context, attach attachedOuput, cmd *exec.Cmd) Output {
 	// Set up buffers for output and errors - we need to retain a copy of stderr for error
 	// creation.
-	var outputBuffer, stderrCopy = makeBuffer(), makeBuffer()
+	var outputBuffer, stderrCopy = makeUnboundedBuffer(), makeUnboundedBuffer()
 
 	// We use this buffered pipe from github.com/djherbis/nio that allows async read and
 	// write operations to the reader and writer portions of the pipe respectively.
@@ -202,7 +202,7 @@ func (o *commandOutput) Read(p []byte) (int, error) {
 	// Otherwise, we can only really read the whole thing and send the data back bit by
 	// bit as read requests come in.
 	if o.mappedData == nil {
-		reader, writer := nio.Pipe(makeBuffer())
+		reader, writer := nio.Pipe(makeUnboundedBuffer())
 		go func() {
 			_, err := o.mapFuncs.Pipe(o.ctx, o.reader, writer, nil)
 			writer.CloseWithError(err)


### PR DESCRIPTION
I noticed LineMaps are not applied in my "fix" for io.Reader in which I kind of completely forgot about LineMaps.

1. Fix io.Reader + line maps
1. More robust tests for various line map scenarios

The implementation is not ideal, there are quite a few layers of buffering. I explored incremental reading of the command output, but it's super hard (impossible?) without lookahead, since we never know when the line has really ended, and LineMap depends on full lines

I wonder if we can lift line map assignment out of output, and into command. Then we can perhaps deal purely with mapped output 

tldr I might have overcomplicated things 😂😂😂

