### PR TITLE
output: make StreamLines accept string instead of bytes

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -24,14 +24,14 @@ var outputTests = []func(c *qt.C, out run.Output, expect string, expectError boo
 	},
 	func(c *qt.C, out run.Output, expect string, expectError bool) {
 		c.Run("StreamLines", func(c *qt.C) {
-			linesC := make(chan []byte, 10)
-			err := out.StreamLines(func(line []byte) {
+			linesC := make(chan string, 10)
+			err := out.StreamLines(func(line string) {
 				linesC <- line
 			})
 			c.Assert(err, qt.IsNil)
 			close(linesC)
 
-			var lines [][]byte
+			var lines []string
 			for l := range linesC {
 				lines = append(lines, l)
 			}

--- a/output.go
+++ b/output.go
@@ -31,7 +31,7 @@ type Output interface {
 	Stream(dst io.Writer) error
 	// StreamLines writes mapped output from the command and sends it line by line to the
 	// destination callback until command completion.
-	StreamLines(dst func(line []byte)) error
+	StreamLines(dst func(line string)) error
 	// Lines waits for command completion and aggregates mapped output from the command as
 	// a slice of lines.
 	Lines() ([]string, error)
@@ -145,10 +145,12 @@ func (o *commandOutput) Stream(dst io.Writer) error {
 	return err
 }
 
-func (o *commandOutput) StreamLines(dst func(line []byte)) error {
+func (o *commandOutput) StreamLines(dst func(line string)) error {
 	go o.waitAndClose()
 
-	_, err := o.mapFuncs.Pipe(o.ctx, o.reader, newLineWriter(dst), nil)
+	_, err := o.mapFuncs.Pipe(o.ctx, o.reader, newLineWriter(func(b []byte) {
+		dst(string(b))
+	}), nil)
 	return err
 }
 

--- a/output_error.go
+++ b/output_error.go
@@ -14,7 +14,7 @@ func (o *errorOutput) StdOut() Output     { return o }
 func (o *errorOutput) Map(LineMap) Output { return o }
 
 func (o *errorOutput) Stream(io.Writer) error           { return o.err }
-func (o *errorOutput) StreamLines(func([]byte)) error   { return o.err }
+func (o *errorOutput) StreamLines(func(string)) error   { return o.err }
 func (o *errorOutput) Lines() ([]string, error)         { return nil, o.err }
 func (o *errorOutput) String() (string, error)          { return "", o.err }
 func (o *errorOutput) JQ(string) ([]byte, error)        { return nil, o.err }


### PR DESCRIPTION
The main intent is to allow command output to be streamed to [`lib/output.Output`](https://sourcegraph.com/github.com/bobheadxi/sourcegraph/-/blob/lib/output/output.go?L25&utm_source=VSCode-2.2.3), e.g. 

```go
cmd.Run(ctx, `brew install git`).StreamLines(std.Out.Write)
cmd.Run(ctx, `brew install git`).StreamLines(std.Out.Verbose)
```

I was originally going to add this to `lib/output`, e.g. https://github.com/sourcegraph/sourcegraph/pull/36594, but I stumbled across `Pending` and `output.Writer` (linked above). The integration is probably neater by changing the interface here - besides, if you're getting data line-by-line then you're probably already thinking in terms of processed data (strings) anyway.

Context: experimenting with https://github.com/sourcegraph/sourcegraph/pull/36556 and thinking we can have each `Action` be provided `pending` for neater output. `pending` implements only the `Writer` interface