### PR TITLE
add BashWithOpts command for strict bash exec

### DIFF
--- a/command.go
+++ b/command.go
@@ -14,10 +14,10 @@ import (
 type BashOpt string
 
 const (
-    // 'pipefail' instructs bash to fail an entire statement if any command in a pipefails. 
-    BashOptPipeFail BashOpt = "pipefail"
-    // 'errexit' lets bash exit with an err exit code if a command fails .
-    BashOptErrExit  BashOpt = "errexit"
+	// 'pipefail' instructs bash to fail an entire statement if any command in a pipefails.
+	BashOptPipeFail BashOpt = "pipefail"
+	// 'errexit' lets bash exit with an err exit code if a command fails .
+	BashOptErrExit BashOpt = "errexit"
 )
 
 // StrictBashOpts contains options that effectively enforce safe execution of bash commands.
@@ -53,12 +53,12 @@ func Cmd(ctx context.Context, parts ...string) *Command {
 	}
 }
 
-// BashWithOpts appends all the given bash options to the bash command with '-o'. The given parts
+// BashWith appends all the given bash options to the bash command with '-o'. The given parts
 // is then joined together to be executed with 'bash -c'
 //
 // The final command will have the following format: bash -o option-1 -c command. For recommended strict bash options
 // see StrictBashOpts, which has 'pipefail' and 'errexit' options
-func BashWithOpts(ctx context.Context, opts []BashOpt, parts ...string) *Command {
+func BashWith(ctx context.Context, opts []BashOpt, parts ...string) *Command {
 	var bash strings.Builder
 	bash.WriteString("bash")
 	for _, v := range opts {

--- a/command.go
+++ b/command.go
@@ -10,12 +10,18 @@ import (
 	"bitbucket.org/creachadair/shell"
 )
 
+// BashOpt denotes options for running bash commands. For more options see 'man bash'
 type BashOpt string
 
-// StrictBashOpts contains two bash options 'pipefail' and 'errexit'. 'pipefail' instructs bash to fail an entire statement if any command in a pipefails. 
-// 'errexit' lets bash exit with an err exit code if a command fails . For more options see
-// 'man bash'
-var StrictBashOpts = []BashOpt{"pipefail", "errexit"}
+const (
+    // 'pipefail' instructs bash to fail an entire statement if any command in a pipefails. 
+    BashOptPipeFail BashOpt = "pipefail"
+    // 'errexit' lets bash exit with an err exit code if a command fails .
+    BashOptErrExit  BashOpt = "errexit"
+)
+
+// StrictBashOpts contains options that effectively enforce safe execution of bash commands.
+var StrictBashOpts = []BashOpt{BashOptPipeFail, BashOptErrExit}
 
 // Command builds a command for execution. Functions modify the underlying command.
 type Command struct {

--- a/command.go
+++ b/command.go
@@ -50,7 +50,7 @@ func Cmd(ctx context.Context, parts ...string) *Command {
 // BashWithOpts appends all the given bash options to the bash command with '-o'. The given parts
 // is then joined together to be executed with 'bash -c'
 //
-// The final command will have the following format: bash -o option-1 -c command. For recommened strict bash options
+// The final command will have the following format: bash -o option-1 -c command. For recommended strict bash options
 // see StrictBashOpts, which has 'pipefail' and 'errexit' options
 func BashWithOpts(ctx context.Context, opts []BashOpt, parts ...string) *Command {
 	var bash strings.Builder

--- a/command.go
+++ b/command.go
@@ -12,7 +12,7 @@ import (
 
 type BashOpt string
 
-// StrictBashOpts contains two bash options 'pipefail' and 'errexit' which ensures the scripts executed by bash exit on errors
+// StrictBashOpts contains two bash options 'pipefail' and 'errexit'. 'pipefail' instructs bash to fail an entire statement if any command in a pipefails. 
 // 'errexit' lets bash exit with an err exit code if a command fails . For more options see
 // 'man bash'
 var StrictBashOpts = []BashOpt{"pipefail", "errexit"}

--- a/command.go
+++ b/command.go
@@ -13,7 +13,7 @@ import (
 type BashOpt string
 
 // StrictBashOpts contains two bash options 'pipefail' and 'errexit' which ensures the scripts executed by bash exit on errors
-// and if one command in a pipe statement fails the entire pipe command exits with that status code. For more options see
+// 'errexit' lets bash exit with an err exit code if a command fails . For more options see
 // 'man bash'
 var StrictBashOpts = []BashOpt{"pipefail", "errexit"}
 

--- a/command_test.go
+++ b/command_test.go
@@ -259,7 +259,7 @@ func TestBashOpts(t *testing.T) {
 		})
 		c.Run("pipe command should fail with StrictBash", func(c *qt.C) {
 			// with StrictBashOpts, since 'grep 999' fails in the pipe, the entire command is considered to have failed
-			_, err := run.BashWithOpts(ctx, run.StrictBashOpts, pipeCmd).StdOut().Run().String()
+			_, err := run.BashWith(ctx, run.StrictBashOpts, pipeCmd).StdOut().Run().String()
 			c.Assert(err, qt.IsNotNil)
 		})
 


### PR DESCRIPTION
In https://github.com/sourcegraph/run/issues/44 a command seems to not return an error from a command that is executed. Upon further investigation it is because the command is executed with `bash -c`, which means bash default options which means that if the last command of a pipe succeeds, the entire pipe statement is considered to have succeeded regardless if earlier statements have failed. A common "fix" for this is to enable `pipefail` and `errexit` options in bash.

This PR adds easier way for users to execute some bash scripts with "strict" bash and possibly avoid unexpected errors.

Closes #44 