### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.25.9'
+        go-version: '1.26.4'
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/run
 
-go 1.25
+go 1.26.4
 
 require (
 	bitbucket.org/creachadair/shell v0.0.7

--- a/jq.go
+++ b/jq.go
@@ -39,7 +39,7 @@ func execJQBytes(ctx context.Context, jqCoode *gojq.Code, content []byte) ([]byt
 
 // execJQ executes the compiled jq query against content from reader.
 func execJQ(ctx context.Context, jqCode *gojq.Code, reader io.Reader) ([]byte, error) {
-	var input interface{}
+	var input any
 	if err := json.NewDecoder(reader).Decode(&input); err != nil {
 		return nil, fmt.Errorf("json: %w", err)
 	}


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)