### PR TITLE
Add SCIP code intelligence upload workflow

### DIFF
--- a/.github/workflows/scip-go.yml
+++ b/.github/workflows/scip-go.yml
@@ -1,0 +1,34 @@
+name: scip-go
+"on":
+  push:
+    branches: [main]
+    paths:
+      - '**.go'
+      - '**/scip-go.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scip-go:
+    if: github.repository_owner == 'sourcegraph'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run scip-go and upload
+        uses: sourcegraph/scip-go-action@v2
+        with:
+          sourcegraph-url: https://sourcegraph.sourcegraph.com/
+          sourcegraph-token: ${{ secrets.SRC_ACCESS_TOKEN_S2 }}
+          upload: true


### PR DESCRIPTION
Adds a GitHub Actions workflow that generates a SCIP index with
[`scip-go`](https://github.com/sourcegraph/scip-go-action) and uploads it to
this Sourcegraph instance on every push to the default branch, so this
repository has precise code navigation.

The workflow:
- Triggers on pushes that touch Go files (or the workflow itself) to the default branch.
- Uses `sourcegraph/scip-go-action@v2` to build and upload the index.
- Uploads to `https://sourcegraph.sourcegraph.com/` using the `SRC_ACCESS_TOKEN_S2` repository/organization secret.

Requires the `SRC_ACCESS_TOKEN_S2` Actions secret to be available to this repository.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/342)